### PR TITLE
5 add npmnpx to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # PHPEnv | Changelog
 
+## [Unreleased]
+### Added
+- Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)
+
+### Changed
+- Upgraded from PHP `8.2` > `8.3` [#8](https://github.com/DanielWinning/phpenv/issues/8)
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixes issue [#6](https://github.com/DanielWinning/phpenv/issues/6)
+
+### Security
+- N/A
+
+---
+
 ## [1.2.0] - 2024-03-23
 ### Added
 - Added `CHANGELOG.md`
@@ -7,7 +28,7 @@
 ### Changed
 - Added `coverage` to `xdebug.mode`
 - Added `xdebug.idekey` set to `PHPENV`
-- Attach command now enters into the project directory
+- Attach command now enters into the project root (`/var/www/html`)
 
 ### Deprecated
 - N/A

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - host.docker.internal:host-gateway
     volumes:
       - ${PROJECT_DIRECTORY}:/var/www/html:cached
+    ports:
+      - "9003:9003"
   database:
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 
 RUN mkdir -p /var/ww/html
 RUN mkdir -p /var/www/certbot
@@ -15,6 +15,16 @@ RUN apt-get -qq update && apt-get -qq install -y \
     bash \
     dnsutils
 
+ENV NVM_DIR /root/.nvm
+ENV NODE_VERSION 20
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION
+
+COPY --from=node:20 /usr/local/bin/npx /usr/local/bin/npx
+
 RUN docker-php-ext-configure intl > /dev/null
 RUN docker-php-ext-install mysqli \
     pdo \
@@ -23,8 +33,7 @@ RUN docker-php-ext-install mysqli \
     intl \
     opcache > /dev/null
 
-RUN pecl install xdebug \
-    redis \
+RUN pecl install xdebug redis \
     && docker-php-ext-enable redis
 
 COPY ./xdebug.ini "${PHP_INI_DIR}/conf.d"


### PR DESCRIPTION
### Added
- Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)

### Changed
- Upgraded from PHP `8.2` > `8.3` [#8](https://github.com/DanielWinning/phpenv/issues/8)

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixes issue [#6](https://github.com/DanielWinning/phpenv/issues/6)

### Security
- N/A