### PR TITLE
12 set dynamic host port for xdebug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # PHPEnv | Changelog
 
+## [Unreleased]
+### Added
+- Additional PHP extensions included by default: `gd, soap, xml, bcmath, exif, mbstring, curl, zip`
+
+### Changed
+- Reduced range of dynamic host port generation to avoid conflicts and avoid assigning a "well-known" port
+- More robust port checking to prevent ports being assigned that Docker can't access
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixed typo in `Dockerfile` that was creating extra unneeded directories in the container
+- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic host port for PHP container
+
+### Security
+- N/A
+
+---
+
 ## [1.3.0] - 2024-03-23
 ### Added
 - Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ on a project by project basis.
 Easily create Docker containers configured for development with Laravel, Symfony or plain vanilla PHP, with the following services:
 
 - Nginx
-- MySQL
-- PHP 8.2 + opcache + xdebug
+- MySQL 8
+- PHP 8.3 including OpCache and XDebug
 - Redis
 
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10"
+    },
+    "require": {
+        "ext-sockets": "*"
     }
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ${PROJECT_DIRECTORY}:/var/www/html:cached
     ports:
-      - "9003:9003"
+      - ${PHP_PORT}:9003
   database:
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3-fpm
 
-RUN mkdir -p /var/ww/html
+RUN mkdir -p /var/www/html
 RUN mkdir -p /var/www/certbot
 RUN mkdir -p /etc/letsencrypt
 
@@ -26,12 +26,8 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
 COPY --from=node:20 /usr/local/bin/npx /usr/local/bin/npx
 
 RUN docker-php-ext-configure intl > /dev/null
-RUN docker-php-ext-install mysqli \
-    pdo \
-    pdo_mysql \
-    sockets \
-    intl \
-    opcache > /dev/null
+RUN docker-php-ext-install mysqli pdo pdo_mysql sockets intl gd mbstring zip exif bcmath soap  \
+    xml opcache curl > /dev/null
 
 RUN pecl install xdebug redis \
     && docker-php-ext-enable redis

--- a/src/Classes/Command/Commands/Build.php
+++ b/src/Classes/Command/Commands/Build.php
@@ -81,7 +81,7 @@ final class Build extends Command implements RunnableCommandInterface
             ob_start();
         }
 
-        passthru(sprintf('%s', $dockerComposeCommand), $buildCommandError);
+        passthru(sprintf('%s 2>&1', $dockerComposeCommand), $buildCommandError);
 
         if (!$this->options->hasFlag('debug')) {
             ob_end_clean();

--- a/src/Classes/Command/Commands/Build.php
+++ b/src/Classes/Command/Commands/Build.php
@@ -81,7 +81,7 @@ final class Build extends Command implements RunnableCommandInterface
             ob_start();
         }
 
-        passthru(sprintf('%s 2>&1', $dockerComposeCommand), $buildCommandError);
+        passthru(sprintf('%s', $dockerComposeCommand), $buildCommandError);
 
         if (!$this->options->hasFlag('debug')) {
             ob_end_clean();
@@ -111,19 +111,16 @@ final class Build extends Command implements RunnableCommandInterface
      */
     private function createEnvFile(): void
     {
-        $nginxPort = $this->generateRandomPort();
-        $mysqlPort = $this->generateRandomPort();
-        $redisPort = $this->generateRandomPort();
-
         file_put_contents(
             $this->getPaths('env'),
             sprintf(
-                "PROJECT_DIRECTORY=%s\nPROJECT_NAME=%s\nNGINX_PORT=%s\nMYSQL_PORT=%s\nREDIS_PORT=%s\n",
+                "PROJECT_DIRECTORY=%s\nPROJECT_NAME=%s\nNGINX_PORT=%s\nMYSQL_PORT=%s\nREDIS_PORT=%s\nPHP_PORT=%s",
                 $this->options->get('path'),
                 $this->options->get('name'),
-                $nginxPort,
-                $mysqlPort,
-                $redisPort
+                $this->generateRandomPort(),
+                $this->generateRandomPort(),
+                $this->generateRandomPort(),
+                $this->generateRandomPort()
             )
         );
     }
@@ -163,12 +160,17 @@ final class Build extends Command implements RunnableCommandInterface
         $portInUse = true;
 
         while ($portInUse) {
-            $port = rand(1, 65535);
+            $port = rand(49152, 65535);
 
-            if (!is_resource(@fsockopen('localhost', (string) $port)) && !in_array($port, $this->ports)) {
+            $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+            $bindResult = @socket_bind($socket, '127.0.0.1', $port);
+
+            if ($bindResult && !in_array($port, $this->ports)) {
                 $this->ports[] = $port;
                 $portInUse = false;
             }
+
+            socket_close($socket);
         }
 
         return (string) $port;


### PR DESCRIPTION
### Added
- Additional PHP extensions included by default: `gd, soap, xml, bcmath, exif, mbstring, curl, zip`

### Changed
- Reduced range of dynamic host port generation to avoid conflicts and avoid assigning a "well-known" port
- More robust port checking to prevent ports being assigned that Docker can't access

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed typo in `Dockerfile` that was creating extra unneeded directories in the container
- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic host port for PHP container

### Security
- N/A