### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # PHPEnv | Changelog
 
+## [Unreleased]
+### Added
+- Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)
+
+### Changed
+- Upgraded from PHP `8.2` > `8.3` [#8](https://github.com/DanielWinning/phpenv/issues/8)
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixes issue [#6](https://github.com/DanielWinning/phpenv/issues/6)
+
+### Security
+- N/A
+
+---
+
 ## [1.2.0] - 2024-03-23
 ### Added
 - Added `CHANGELOG.md`
@@ -7,7 +28,7 @@
 ### Changed
 - Added `coverage` to `xdebug.mode`
 - Added `xdebug.idekey` set to `PHPENV`
-- Attach command now enters into the project directory
+- Attach command now enters into the project root (`/var/www/html`)
 
 ### Deprecated
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # PHPEnv | Changelog
 
-## [Unreleased]
+## [1.4.0] - 2024-03-24
 ### Added
-- Additional PHP extensions included by default: `gd, soap, xml, bcmath, exif, mbstring, curl, zip`
+- Additional PHP extensions included by default: `bcmath, exif`
 
 ### Changed
-- Reduced range of dynamic host port generation to avoid conflicts and avoid assigning a "well-known" port
+- Reduced range of dynamic port generation to avoid conflicts and avoid assigning a "well-known" port
 - More robust port checking to prevent ports being assigned that Docker can't access
 
 ### Deprecated
@@ -16,7 +16,7 @@
 
 ### Fixed
 - Fixed typo in `Dockerfile` that was creating extra unneeded directories in the container
-- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic host port for PHP container
+- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic client port for PHP container
 
 ### Security
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # PHPEnv | Changelog
 
+## [Unreleased]
+### Added
+- Additional PHP extensions included by default: `gd, soap, xml, bcmath, exif, mbstring, curl, zip`
+
+### Changed
+- Reduced range of dynamic host port generation to avoid conflicts and avoid assigning a "well-known" port
+- More robust port checking to prevent ports being assigned that Docker can't access
+
+### Deprecated
+- N/A
+
+### Removed
+- N/A
+
+### Fixed
+- Fixed typo in `Dockerfile` that was creating extra unneeded directories in the container
+- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic host port for PHP container
+
+### Security
+- N/A
+
+---
+
 ## [1.3.0] - 2024-03-23
 ### Added
 - Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PHPEnv | Changelog
 
-## [Unreleased]
+## [1.3.0] - 2024-03-23
 ### Added
 - Added `nvm`, `node`, `npm` and `npx` to the PHP container [#5](https://github.com/DanielWinning/phpenv/issues/5)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.2.0-blue" alt="Version 1.2.0">
+<img src="https://img.shields.io/badge/Version-1.3.0-blue" alt="Version 1.3.0">
 <!-- PHP Coverage Badge -->
 <img src="https://img.shields.io/badge/PHP Coverage-50.74%25-red" alt="PHP Coverage 50.74%">
 <!-- License Badge -->

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div>
 <!-- Version Badge -->
-<img src="https://img.shields.io/badge/Version-1.3.0-blue" alt="Version 1.3.0">
+<img src="https://img.shields.io/badge/Version-1.4.0-blue" alt="Version 1.4.0">
 <!-- PHP Coverage Badge -->
-<img src="https://img.shields.io/badge/PHP Coverage-50.74%25-red" alt="PHP Coverage 50.74%">
+<img src="https://img.shields.io/badge/PHP Coverage-52.84%25-red" alt="PHP Coverage 52.84%">
 <!-- License Badge -->
 <img src="https://img.shields.io/badge/License-GPL--3.0--only-34ad9b" alt="License GPL--3.0--only">
 </div>

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ on a project by project basis.
 Easily create Docker containers configured for development with Laravel, Symfony or plain vanilla PHP, with the following services:
 
 - Nginx
-- MySQL
-- PHP 8.2 + opcache + xdebug
+- MySQL 8
+- PHP 8.3 including OpCache and XDebug
 - Redis
 
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10"
+    },
+    "require": {
+        "ext-sockets": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dannyxcii/phpenv",
     "description": "Easily spin up Docker containers for local PHP development.",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "type": "library",
     "license": "GPL-3.0-only",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dannyxcii/phpenv",
     "description": "Easily spin up Docker containers for local PHP development.",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "type": "library",
     "license": "GPL-3.0-only",
     "autoload": {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - host.docker.internal:host-gateway
     volumes:
       - ${PROJECT_DIRECTORY}:/var/www/html:cached
+    ports:
+      - "9003:9003"
   database:
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ${PROJECT_DIRECTORY}:/var/www/html:cached
     ports:
-      - "9003:9003"
+      - ${PHP_PORT}:9003
   database:
     image: mysql:8.0
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --lower_case_table_names=1

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3-fpm
 
-RUN mkdir -p /var/ww/html
+RUN mkdir -p /var/www/html
 RUN mkdir -p /var/www/certbot
 RUN mkdir -p /etc/letsencrypt
 
@@ -26,12 +26,8 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
 COPY --from=node:20 /usr/local/bin/npx /usr/local/bin/npx
 
 RUN docker-php-ext-configure intl > /dev/null
-RUN docker-php-ext-install mysqli \
-    pdo \
-    pdo_mysql \
-    sockets \
-    intl \
-    opcache > /dev/null
+RUN docker-php-ext-install mysqli pdo pdo_mysql sockets intl gd mbstring zip exif bcmath soap  \
+    xml opcache curl > /dev/null
 
 RUN pecl install xdebug redis \
     && docker-php-ext-enable redis

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 
 RUN mkdir -p /var/ww/html
 RUN mkdir -p /var/www/certbot
@@ -15,6 +15,16 @@ RUN apt-get -qq update && apt-get -qq install -y \
     bash \
     dnsutils
 
+ENV NVM_DIR /root/.nvm
+ENV NODE_VERSION 20
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION
+
+COPY --from=node:20 /usr/local/bin/npx /usr/local/bin/npx
+
 RUN docker-php-ext-configure intl > /dev/null
 RUN docker-php-ext-install mysqli \
     pdo \
@@ -23,8 +33,7 @@ RUN docker-php-ext-install mysqli \
     intl \
     opcache > /dev/null
 
-RUN pecl install xdebug \
-    redis \
+RUN pecl install xdebug redis \
     && docker-php-ext-enable redis
 
 COPY ./xdebug.ini "${PHP_INI_DIR}/conf.d"

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -26,13 +26,12 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
 COPY --from=node:20 /usr/local/bin/npx /usr/local/bin/npx
 
 RUN docker-php-ext-configure intl > /dev/null
-RUN docker-php-ext-install mysqli pdo pdo_mysql sockets intl gd mbstring zip exif bcmath soap  \
-    xml opcache curl > /dev/null
+RUN docker-php-ext-install mysqli pdo pdo_mysql sockets intl exif bcmath opcache > /dev/null
 
 RUN pecl install xdebug redis \
     && docker-php-ext-enable redis
 
-COPY ./xdebug.ini "${PHP_INI_DIR}/conf.d"
+COPY ./xdebug.ini.tmp "${PHP_INI_DIR}/conf.d/xdebug.ini"
 COPY ./opcache.ini "${PHP_INI_DIR}/conf.d"
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/docker/php-fpm/xdebug.ini
+++ b/docker/php-fpm/xdebug.ini
@@ -4,3 +4,4 @@ xdebug.start_with_request=yes
 xdebug.discover_client_host=0
 xdebug.client_host=host.docker.internal
 xdebug.idekey=PHPENV
+xdebug.client_port=PHP_PORT

--- a/src/Classes/Command/Command.php
+++ b/src/Classes/Command/Command.php
@@ -76,6 +76,7 @@ class Command implements CommandInterface
             'docker' => sprintf('%s/docker', $projectRoot),
             'data' => sprintf('%s/docker/data', $projectRoot),
             'nginx' => sprintf('%s/docker/nginx', $projectRoot),
+            'php-fpm' => sprintf('%s/docker/php-fpm', $projectRoot),
         ];
 
         if ($this->options->get('name')) {

--- a/src/Classes/Command/Commands/Build.php
+++ b/src/Classes/Command/Commands/Build.php
@@ -43,6 +43,8 @@ final class Build extends Command implements RunnableCommandInterface
             return CommandStatus::Error;
         }
 
+        $this->removeTemporaryIni();
+
         return CommandStatus::Success;
     }
 
@@ -54,6 +56,7 @@ final class Build extends Command implements RunnableCommandInterface
         $this->writer->writeInfo('Creating configuration files...');
         mkdir($this->getPaths('project'));
         $this->createEnvFile();
+        $this->prepareTemporaryXdebugIni();
         $this->writer->writeInfo('Configuration files created.');
     }
 
@@ -148,6 +151,8 @@ final class Build extends Command implements RunnableCommandInterface
                 ob_end_clean();
             }
         }
+
+        $this->removeTemporaryIni();
     }
 
     /**
@@ -174,5 +179,29 @@ final class Build extends Command implements RunnableCommandInterface
         }
 
         return (string) $port;
+    }
+
+    /**
+     * @return void
+     */
+    private function prepareTemporaryXdebugIni(): void
+    {
+        $xdebugPath = sprintf('%s/xdebug.ini', $this->getPaths('php-fpm'));
+        $xdebugTmpPath = sprintf('%s/xdebug.ini.tmp', $this->getPaths('php-fpm'));
+        $xdebugIni = file_get_contents($xdebugPath);
+        $xdebugIni = str_replace('PHP_PORT', $this->ports[3] ?? '9003', $xdebugIni);
+
+        file_put_contents($xdebugTmpPath, $xdebugIni);
+    }
+
+    /**
+     * @return void
+     */
+    private function removeTemporaryIni(): void
+    {
+        $xdebugTmpIni = sprintf('%s/xdebug.ini.tmp', $this->getPaths('php-fpm'));
+
+        unlink($xdebugTmpIni);
+
     }
 }

--- a/src/Classes/Command/Commands/Build.php
+++ b/src/Classes/Command/Commands/Build.php
@@ -111,19 +111,16 @@ final class Build extends Command implements RunnableCommandInterface
      */
     private function createEnvFile(): void
     {
-        $nginxPort = $this->generateRandomPort();
-        $mysqlPort = $this->generateRandomPort();
-        $redisPort = $this->generateRandomPort();
-
         file_put_contents(
             $this->getPaths('env'),
             sprintf(
-                "PROJECT_DIRECTORY=%s\nPROJECT_NAME=%s\nNGINX_PORT=%s\nMYSQL_PORT=%s\nREDIS_PORT=%s\n",
+                "PROJECT_DIRECTORY=%s\nPROJECT_NAME=%s\nNGINX_PORT=%s\nMYSQL_PORT=%s\nREDIS_PORT=%s\nPHP_PORT=%s",
                 $this->options->get('path'),
                 $this->options->get('name'),
-                $nginxPort,
-                $mysqlPort,
-                $redisPort
+                $this->generateRandomPort(),
+                $this->generateRandomPort(),
+                $this->generateRandomPort(),
+                $this->generateRandomPort()
             )
         );
     }
@@ -163,12 +160,17 @@ final class Build extends Command implements RunnableCommandInterface
         $portInUse = true;
 
         while ($portInUse) {
-            $port = rand(1, 65535);
+            $port = rand(49152, 65535);
 
-            if (!is_resource(@fsockopen('localhost', (string) $port)) && !in_array($port, $this->ports)) {
+            $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+            $bindResult = @socket_bind($socket, '127.0.0.1', $port);
+
+            if ($bindResult && !in_array($port, $this->ports)) {
                 $this->ports[] = $port;
                 $portInUse = false;
             }
+
+            socket_close($socket);
         }
 
         return (string) $port;

--- a/tests/Unit/Commands/BuildTest.php
+++ b/tests/Unit/Commands/BuildTest.php
@@ -29,6 +29,13 @@ class BuildTest extends TestCase
     }
 
     #[Test]
+    public function throwsInvalidArgumentExceptionIfProvidedTooManyArguments()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Build(new CommandOptions(['phpenv', 'build', 'test', 'test', 'test', 'test']), new Writer());
+    }
+
+    #[Test]
     public function returnsErrorWhenProjectNameIsInUse(): void
     {
         $buildCommand = new Build(new CommandOptions([
@@ -61,8 +68,8 @@ class BuildTest extends TestCase
 
         $buildCommand->createConfigurationFiles();
 
-        $this->assertEquals(true, file_exists($buildCommand->getPaths('project')));
-        $this->assertEquals(true, file_exists($buildCommand->getPaths('env')));
+        $this->assertTrue(file_exists($buildCommand->getPaths('project')));
+        $this->assertTrue(file_exists($buildCommand->getPaths('env')));
 
         if (file_exists($buildCommand->getPaths('env'))) {
             unlink($buildCommand->getPaths('project') . '/.env');
@@ -70,6 +77,10 @@ class BuildTest extends TestCase
 
         if (file_exists($buildCommand->getPaths('project'))) {
             rmdir($buildCommand->getPaths('project'));
+        }
+
+        if (file_exists($buildCommand->getPaths('php-fpm') . '/xdebug.ini.tmp')) {
+            unlink($buildCommand->getPaths('php-fpm') . '/xdebug.ini.tmp');
         }
     }
 }


### PR DESCRIPTION
### Added
- Additional PHP extensions included by default: `bcmath, exif`

### Changed
- Reduced range of dynamic port generation to avoid conflicts and avoid assigning a "well-known" port
- More robust port checking to prevent ports being assigned that Docker can't access

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- Fixed typo in `Dockerfile` that was creating extra unneeded directories in the container
- Fixes [#12](https://github.com/DanielWinning/phpenv/issues/12) - sets dynamic client port for PHP container

### Security
- N/A

---

- Closes #12 